### PR TITLE
Fix day of week (0=Sunday)

### DIFF
--- a/crontabula/__init__.py
+++ b/crontabula/__init__.py
@@ -77,7 +77,7 @@ class Crontab:
                         hour=hour,
                         minute=minute,
                     )
-                    if dt.weekday() in self.day_of_week:
+                    if _day_of_week_to_cron(dt.weekday()) in self.day_of_week:
                         yield dt
 
     def dates(self, start: Optional[datetime.date] = None) -> Iterator[datetime.date]:
@@ -105,7 +105,7 @@ class Crontab:
                     if month == anchor.month and day_of_month < anchor.day:
                         continue
 
-                    if day_of_week not in self.day_of_week:
+                    if _day_of_week_to_cron(day_of_week) not in self.day_of_week:
                         continue
 
                     if day_of_month not in self.day_of_month:
@@ -195,3 +195,8 @@ def _try_int(v, max_value: int, min_value: int) -> int:
         )
 
     return result
+
+
+def _day_of_week_to_cron(day_of_week: int):
+    """Convert Python day-of-week (0 = Monday) to Cron (0 = Sunday)"""
+    return (day_of_week + 1) % 7

--- a/crontabula/__init__.py
+++ b/crontabula/__init__.py
@@ -70,15 +70,13 @@ class Crontab:
                     if is_start_hour and minute < anchor.minute:
                         continue
 
-                    dt = datetime.datetime(
+                    yield datetime.datetime(
                         year=day.year,
                         month=day.month,
                         day=day.day,
                         hour=hour,
                         minute=minute,
                     )
-                    if _day_of_week_to_cron(dt.weekday()) in self.day_of_week:
-                        yield dt
 
     def dates(self, start: Optional[datetime.date] = None) -> Iterator[datetime.date]:
         """

--- a/crontabula/__init__.py
+++ b/crontabula/__init__.py
@@ -55,7 +55,6 @@ class Crontab:
         """
         anchor = start if start else datetime.datetime.now()
         anchor_date = anchor.date()
-        year = anchor.year
 
         for day in self.dates(anchor_date):
             is_start_day = day == anchor_date

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -43,7 +43,7 @@ def test_next():
     now = datetime.datetime.now()
     next_iteration = crontab.next
     assert next_iteration > now
-    assert next_iteration == datetime.datetime(2022, 4, 1, 3, 0)
+    assert next_iteration == datetime.datetime(2022, 4, 4, 3, 0)
 
 
 @pytest.mark.freeze_time("2022-03-31 23:00")
@@ -115,3 +115,21 @@ def test_minutes():
 def test_year():
     crontab = crontabula.parse("0 0 * 4 *")
     assert crontab.next == datetime.datetime(2023, 4, 1)
+
+
+@pytest.mark.parametrize(
+    "cron_day_of_week, py_day_of_week",
+    [
+        (0, 6),  # Sunday
+        (1, 0),  # Monday
+        (2, 1),  # Tuesday
+        (3, 2),  # Wednesday
+        (4, 3),  # Thursday
+        (5, 4),  # Friday
+        (6, 5),  # Saturday
+    ],
+)
+@pytest.mark.freeze_time("2022-01-01")
+def test_day_of_week(cron_day_of_week, py_day_of_week):
+    crontab = crontabula.parse(f"0 0 * 2 {cron_day_of_week}")
+    assert crontab.next.weekday() == py_day_of_week


### PR DESCRIPTION
I assume the intention was to match POSIX cron, but Python's different numbering convention caused the bug.